### PR TITLE
Add support for initializing new repositories with git wt init

### DIFF
--- a/git-wt
+++ b/git-wt
@@ -1,5 +1,106 @@
 #!/bin/bash
 
+init_new_repo() {
+  echo "Initializing new git-wt repository..."
+  echo ""
+
+  # Default branch name
+  primary_branch="main"
+
+  # Collect existing files (if any)
+  has_files=false
+  if [ "$(ls -A . 2>/dev/null)" ]; then
+    has_files=true
+    echo "Found existing files - they will be added to the initial commit"
+    echo ""
+  fi
+
+  # Create temporary directory for existing files
+  temp_work=""
+  if [ "$has_files" = true ]; then
+    temp_work=".git-wt-temp-work-$$"
+    mkdir "$temp_work"
+    find . -maxdepth 1 ! -name . ! -name .. ! -name "$temp_work" \
+      -exec mv {} "$temp_work/" \; 2>/dev/null || true
+  fi
+
+  # Initialize bare repository
+  echo "Creating bare repository..."
+  git init --bare .git
+
+  # Configure git in the bare repo
+  git -C .git config --bool core.bare true
+  git -C .git config user.name "git-wt"
+  git -C .git config user.email "git-wt@localhost"
+
+  # Set HEAD to main branch
+  echo "ref: refs/heads/$primary_branch" > .git/HEAD
+
+  # Create initial commit on main branch
+  # We need a commit to exist before creating worktrees
+  export GIT_DIR=.git
+
+  # Always need a work tree for commits (even --allow-empty)
+  if [ "$has_files" = false ]; then
+    temp_work=".git-wt-temp-work-$$"
+    mkdir "$temp_work"
+  fi
+
+  export GIT_WORK_TREE="$temp_work"
+
+  if [ "$has_files" = true ]; then
+    # Add all existing files
+    git add -A
+    git commit -m "Initial commit"
+  else
+    # Create empty initial commit
+    git commit --allow-empty -m "Initial commit"
+  fi
+
+  unset GIT_WORK_TREE
+  unset GIT_DIR
+
+  # Create worktree for main branch
+  echo "Creating worktree for '$primary_branch' branch..."
+  if [ "$has_files" = true ]; then
+    # Move preserved files to main/ worktree
+    mv "$temp_work" "$primary_branch"
+
+    # Register as worktree manually
+    repo_root=$(pwd)
+    mkdir -p .git/worktrees/"$primary_branch"
+    echo "gitdir: $repo_root/.git/worktrees/$primary_branch" > "$primary_branch/.git"
+    echo "$repo_root/$primary_branch" > .git/worktrees/"$primary_branch"/gitdir
+    echo "ref: refs/heads/$primary_branch" > .git/worktrees/"$primary_branch"/HEAD
+    touch .git/worktrees/"$primary_branch"/commondir
+    echo "../.." > .git/worktrees/"$primary_branch"/commondir
+
+    # Reset the worktree to sync with the commit
+    cd "$primary_branch"
+    git reset --hard HEAD >/dev/null 2>&1
+    cd ..
+  else
+    # Clean up temp work dir and create worktree normally
+    rm -rf "$temp_work"
+    git worktree add "$primary_branch" "$primary_branch" 2>&1 | grep -v "^Preparing worktree" || true
+  fi
+
+  # Success message
+  echo ""
+  echo "Successfully initialized git-wt repository!"
+  echo ""
+  echo "Repository structure:"
+  echo "  .git/                    (bare repository)"
+  echo "  $primary_branch/         (worktree - primary branch)"
+  echo ""
+  if [ "$has_files" = true ]; then
+    echo "Existing files have been committed to the '$primary_branch' branch"
+    echo ""
+  fi
+  echo "Worktree list:"
+  git worktree list
+}
+
 case "$1" in
   a|add)
     shift
@@ -84,11 +185,20 @@ case "$1" in
 
     # Pre-flight checks
 
-    # 1. Verify we're in a git repository
-    if ! git rev-parse --git-dir >/dev/null 2>&1; then
-      echo "Error: Not a git repository"
-      exit 1
+    # 1. Detect if we're in a git repository
+    is_existing_repo=false
+    if git rev-parse --git-dir >/dev/null 2>&1; then
+      is_existing_repo=true
     fi
+
+    # Branch based on repository status
+    if [ "$is_existing_repo" = false ]; then
+      # NEW LOGIC: Initialize new repository from scratch
+      init_new_repo
+      exit 0
+    fi
+
+    # EXISTING LOGIC: Convert existing repository to worktree structure
 
     # 2. Check if already bare
     if [ "$(git rev-parse --is-bare-repository)" = "true" ]; then


### PR DESCRIPTION
## Summary
Implements #1 - `git wt init` now works in directories without an existing git repository, creating a new git-wt repository from scratch.

## Changes
### New Functionality
- **Empty directory**: Creates new repo with empty initial commit and main/ worktree
- **Directory with files**: Creates repo, commits existing files to main branch, sets up main/ worktree
- **Backward compatible**: Existing repo conversion behavior unchanged

### Implementation Details
- Added `init_new_repo()` function to handle new repository initialization
- Modified pre-flight check to detect (not fail) when not in git repository
- Added branching logic to route between new vs existing repo handlers
- Proper worktree registration and index management to ensure clean working tree

### Testing
- Added 2 new BATS integration tests:
  - `init creates new repo in empty directory`
  - `init creates new repo with existing files`
- All existing tests pass: **20 passing, 8 skipped** (28 tests total)
- Manual testing confirms all scenarios work correctly

## Examples

### Empty directory
```bash
mkdir my-project && cd my-project
git wt init
# Result: Creates .git (bare) and main/ worktree with empty commit
```

### Directory with existing files
```bash
mkdir my-project && cd my-project
echo '# My Project' > README.md
echo '*.log' > .gitignore
git wt init
# Result: Files committed to main branch, clean working tree
```

### Existing repo (regression test - still works)
```bash
git init && echo 'test' > file.txt && git add . && git commit -m 'test'
git wt init
# Result: Converts to worktree structure as before
```

Closes #1