### PR TITLE
Add clean command with merge/stale/empty strategies (v0.0.7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,35 @@ After running `git wt init`:
 
 **Note**: `git wt init` will warn you if you have uncommitted changes or untracked files, and ask for confirmation before proceeding. All your work will be safely preserved in the worktree directory.
 
+## Clean
+
+As you work across many branches, worktrees accumulate. `git wt clean` finds and removes the ones you no longer need.
+
+```bash
+git wt clean              # find all stale, merged, or empty worktrees
+git wt clean merge        # worktrees whose branch has been merged into main
+git wt clean stale [days] # worktrees with no activity in N days (default: 30)
+git wt clean empty        # worktrees with no commits and no uncommitted changes
+```
+
+Each candidate is shown with a color-coded tag before you confirm:
+
+```
+Worktrees to clean:
+  /my-repo/feature/auth        [merged]              (refs/heads/feature/auth)
+  /my-repo/spike/old-idea      [stale (47 d)]        (refs/heads/spike/old-idea)
+  /my-repo/scratch/test        [empty]               (refs/heads/scratch/test)
+
+Remove 3 worktree(s)? [y/N]
+```
+
+Use `--dry-run` to preview without making changes, or `--force` to skip the confirmation prompt.
+
+```bash
+git wt clean --dry-run
+git wt clean merge --force
+```
+
 ## Hooks
 
 git-wt supports custom hooks for advanced workflows. To install the built-in git-crypt hooks:

--- a/git-wt
+++ b/git-wt
@@ -428,6 +428,24 @@ format_time_ago() {
   fi
 }
 
+# Helper: Format a unix timestamp as short abbreviated duration (e.g. "2 mo", "14 d")
+format_time_short() {
+  local timestamp="$1"
+  local now diff
+  now=$(date +%s)
+  diff=$((now - timestamp))
+
+  if [ $diff -lt 3600 ]; then
+    echo "$((diff / 60)) min"
+  elif [ $diff -lt 86400 ]; then
+    echo "$((diff / 3600)) h"
+  elif [ $diff -lt 2592000 ]; then
+    echo "$((diff / 86400)) d"
+  else
+    echo "$((diff / 2592000)) mo"
+  fi
+}
+
 # Helper: Format a unix timestamp as YYYY-MM-DD HH:MM
 format_date() {
   local timestamp="$1"
@@ -572,7 +590,7 @@ cmd_clean() {
     fi
 
     local is_merged=false is_stale=false is_empty=false
-    local stale_date="" stale_ago=""
+    local stale_short=""
 
     if [ -z "$subcommand" ] || [ "$subcommand" = "merge" ]; then
       if check_merged "$wt_path" "$short_branch" "$primary_branch"; then
@@ -584,8 +602,7 @@ cmd_clean() {
       LAST_COMMIT_TIME=""
       if check_stale "$wt_path" "$days"; then
         is_stale=true
-        stale_date=$(format_date "$LAST_COMMIT_TIME")
-        stale_ago=$(format_time_ago "$LAST_COMMIT_TIME")
+        stale_short=$(format_time_short "$LAST_COMMIT_TIME")
       fi
     fi
 
@@ -608,18 +625,23 @@ cmd_clean() {
     esac
 
     if [ "$is_candidate" = true ]; then
+      local C_MERGED=$'\033[42;30m'  # green bg, black text
+      local C_STALE=$'\033[43;30m'   # yellow bg, black text
+      local C_EMPTY=$'\033[46;30m'   # cyan bg, black text
+      local C_RESET=$'\033[0m'
+
       local tag_parts=()
-      [ "$is_merged" = true ] && tag_parts+=("merged")
-      [ "$is_stale" = true ] && tag_parts+=("stale: ${stale_date}, ${stale_ago}")
-      [ "$is_empty" = true ] && tag_parts+=("empty")
+      [ "$is_merged" = true ] && tag_parts+=("${C_MERGED} merged ${C_RESET}")
+      [ "$is_stale" = true ]  && tag_parts+=("${C_STALE} stale (${stale_short}) ${C_RESET}")
+      [ "$is_empty" = true ]  && tag_parts+=("${C_EMPTY} empty ${C_RESET}")
 
       local tag_str="" t
       for t in "${tag_parts[@]}"; do
-        [ -z "$tag_str" ] && tag_str="$t" || tag_str="${tag_str}, ${t}"
+        [ -z "$tag_str" ] && tag_str="$t" || tag_str="${tag_str} ${t}"
       done
 
       candidate_paths+=("$wt_path")
-      candidate_tags+=("[${tag_str}]")
+      candidate_tags+=("$tag_str")
       candidate_branches+=("$wt_branch")
     fi
   done
@@ -631,7 +653,7 @@ cmd_clean() {
 
   echo "Worktrees to clean:"
   for i in "${!candidate_paths[@]}"; do
-    printf "  %-35s %-55s (%s)\n" \
+    printf "  %-40s %s  (%s)\n" \
       "${candidate_paths[$i]}" \
       "${candidate_tags[$i]}" \
       "${candidate_branches[$i]}"

--- a/git-wt
+++ b/git-wt
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION="0.0.6"
+VERSION="0.0.7"
 
 # Helper function to find the common git directory where hooks are stored
 find_git_common_dir() {
@@ -47,6 +47,7 @@ COMMANDS:
   remove <path>              Remove a worktree (alias: rm)
   list                       List all worktrees (alias: ls)
   install-hooks <type>       Install hook examples (e.g., git-crypt)
+  clean [merge|stale|empty]  Remove merged, stale, or empty worktrees
   setup [--config-only]      Install git-wt and configure git alias
 
       Note: If you installed via Homebrew, you don't need to run this.
@@ -348,6 +349,314 @@ init_new_repo() {
   git worktree list
 }
 
+# Helper: Get primary branch name (main, master, or from remote HEAD)
+get_primary_branch() {
+  local primary
+  primary=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||')
+  if [ -n "$primary" ]; then
+    echo "$primary"
+    return 0
+  fi
+  if git rev-parse --verify refs/heads/main >/dev/null 2>&1; then
+    echo "main"
+  elif git rev-parse --verify refs/heads/master >/dev/null 2>&1; then
+    echo "master"
+  else
+    git rev-parse --abbrev-ref HEAD 2>/dev/null
+  fi
+}
+
+# Helper: Parse all non-primary worktrees into global arrays
+# Populates: WORKTREE_PATHS, WORKTREE_HEADS, WORKTREE_BRANCHES
+# Skips: first entry (bare/main repo root) and entries marked bare
+get_worktrees() {
+  WORKTREE_PATHS=()
+  WORKTREE_HEADS=()
+  WORKTREE_BRANCHES=()
+
+  local entry_num=0
+  local cur_path="" cur_head="" cur_branch="" is_bare=false
+
+  while IFS= read -r line; do
+    if [[ "$line" == worktree\ * ]]; then
+      if [ $entry_num -gt 1 ] && [ "$is_bare" = false ] && [ -n "$cur_path" ]; then
+        WORKTREE_PATHS+=("$cur_path")
+        WORKTREE_HEADS+=("$cur_head")
+        WORKTREE_BRANCHES+=("$cur_branch")
+      fi
+      entry_num=$((entry_num + 1))
+      cur_path="${line#worktree }"
+      cur_head=""
+      cur_branch=""
+      is_bare=false
+    elif [[ "$line" == HEAD\ * ]]; then
+      cur_head="${line#HEAD }"
+    elif [[ "$line" == branch\ * ]]; then
+      cur_branch="${line#branch }"
+    elif [[ "$line" == "bare" ]]; then
+      is_bare=true
+    fi
+  done < <(git worktree list --porcelain 2>/dev/null)
+
+  # Save last entry
+  if [ $entry_num -gt 1 ] && [ "$is_bare" = false ] && [ -n "$cur_path" ]; then
+    WORKTREE_PATHS+=("$cur_path")
+    WORKTREE_HEADS+=("$cur_head")
+    WORKTREE_BRANCHES+=("$cur_branch")
+  fi
+}
+
+# Helper: Format a unix timestamp as human-readable time ago
+format_time_ago() {
+  local timestamp="$1"
+  local now diff
+  now=$(date +%s)
+  diff=$((now - timestamp))
+
+  if [ $diff -lt 3600 ]; then
+    local minutes=$((diff / 60))
+    [ $minutes -le 1 ] && echo "1 minute ago" || echo "${minutes} minutes ago"
+  elif [ $diff -lt 86400 ]; then
+    local hours=$((diff / 3600))
+    [ $hours -eq 1 ] && echo "1 hour ago" || echo "${hours} hours ago"
+  elif [ $diff -lt 2592000 ]; then
+    local days=$((diff / 86400))
+    [ $days -eq 1 ] && echo "1 day ago" || echo "${days} days ago"
+  else
+    local months=$((diff / 2592000))
+    [ $months -eq 1 ] && echo "1 month ago" || echo "${months} months ago"
+  fi
+}
+
+# Helper: Format a unix timestamp as YYYY-MM-DD HH:MM
+format_date() {
+  local timestamp="$1"
+  date -d "@${timestamp}" "+%Y-%m-%d %H:%M" 2>/dev/null \
+    || date -r "${timestamp}" "+%Y-%m-%d %H:%M" 2>/dev/null
+}
+
+# Helper: Check if a worktree branch is fully merged into the primary branch
+# Returns 0 if merged (branch is ancestor of primary and no diverged HEAD)
+check_merged() {
+  local worktree_path="$1"
+  local short_branch="$2"
+  local primary_branch="$3"
+
+  if ! git merge-base --is-ancestor "refs/heads/$short_branch" "$primary_branch" 2>/dev/null; then
+    return 1
+  fi
+
+  local wt_head branch_head
+  wt_head=$(git -C "$worktree_path" rev-parse HEAD 2>/dev/null)
+  branch_head=$(git rev-parse "refs/heads/$short_branch" 2>/dev/null)
+
+  [ "$wt_head" = "$branch_head" ]
+}
+
+# Helper: Check if a worktree is stale (no commit in N days, no uncommitted changes)
+# Sets global LAST_COMMIT_TIME on success
+# Returns 0 if stale
+check_stale() {
+  local worktree_path="$1"
+  local days="$2"
+
+  local last_commit
+  last_commit=$(git -C "$worktree_path" log -1 --format="%ct" 2>/dev/null)
+
+  if [ -z "$last_commit" ]; then
+    return 1
+  fi
+
+  LAST_COMMIT_TIME="$last_commit"
+
+  if [ -n "$(git -C "$worktree_path" status --porcelain 2>/dev/null)" ]; then
+    return 1
+  fi
+
+  local now age threshold
+  now=$(date +%s)
+  age=$((now - last_commit))
+  threshold=$((days * 86400))
+
+  [ $age -gt $threshold ]
+}
+
+# Helper: Check if a worktree has no unique commits and no uncommitted changes
+# Returns 0 if empty
+check_empty() {
+  local worktree_path="$1"
+  local primary_branch="$2"
+
+  if [ -n "$(git -C "$worktree_path" status --porcelain 2>/dev/null)" ]; then
+    return 1
+  fi
+
+  git -C "$worktree_path" merge-base --is-ancestor HEAD "$primary_branch" 2>/dev/null
+}
+
+# Helper: Remove a worktree, or print what would be removed in dry-run mode
+remove_worktree() {
+  local worktree_path="$1"
+  local dry_run="$2"
+
+  if [ "$dry_run" = true ]; then
+    echo "Would remove: $worktree_path"
+    return 0
+  fi
+
+  if ! git worktree remove "$worktree_path" 2>/dev/null; then
+    git worktree remove --force "$worktree_path"
+  fi
+}
+
+# Clean command: remove merged, stale, or empty worktrees
+cmd_clean() {
+  local dry_run=false
+  local force=false
+  local subcommand=""
+  local days=30
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      -n|--dry-run|--dry)
+        dry_run=true
+        shift
+        ;;
+      -f|--force)
+        force=true
+        shift
+        ;;
+      merge|stale|empty)
+        subcommand="$1"
+        shift
+        ;;
+      [0-9]*)
+        days="$1"
+        shift
+        ;;
+      *)
+        echo "git-wt clean: unknown option '$1'" >&2
+        exit 1
+        ;;
+    esac
+  done
+
+  local primary_branch
+  primary_branch=$(get_primary_branch)
+  if [ -z "$primary_branch" ]; then
+    echo "git-wt clean: could not determine primary branch" >&2
+    exit 1
+  fi
+
+  get_worktrees
+
+  local candidate_paths=()
+  local candidate_tags=()
+  local candidate_branches=()
+
+  local i
+  for i in "${!WORKTREE_PATHS[@]}"; do
+    local wt_path="${WORKTREE_PATHS[$i]}"
+    local wt_branch="${WORKTREE_BRANCHES[$i]}"
+
+    # Skip detached HEAD worktrees
+    if [ -z "$wt_branch" ]; then
+      continue
+    fi
+
+    local short_branch="${wt_branch#refs/heads/}"
+
+    # Skip the primary branch worktree
+    if [ "$short_branch" = "$primary_branch" ]; then
+      continue
+    fi
+
+    local is_merged=false is_stale=false is_empty=false
+    local stale_date="" stale_ago=""
+
+    if [ -z "$subcommand" ] || [ "$subcommand" = "merge" ]; then
+      if check_merged "$wt_path" "$short_branch" "$primary_branch"; then
+        is_merged=true
+      fi
+    fi
+
+    if [ -z "$subcommand" ] || [ "$subcommand" = "stale" ]; then
+      LAST_COMMIT_TIME=""
+      if check_stale "$wt_path" "$days"; then
+        is_stale=true
+        stale_date=$(format_date "$LAST_COMMIT_TIME")
+        stale_ago=$(format_time_ago "$LAST_COMMIT_TIME")
+      fi
+    fi
+
+    if [ -z "$subcommand" ] || [ "$subcommand" = "empty" ]; then
+      if check_empty "$wt_path" "$primary_branch"; then
+        is_empty=true
+      fi
+    fi
+
+    local is_candidate=false
+    case "$subcommand" in
+      merge) [ "$is_merged" = true ] && is_candidate=true ;;
+      stale) [ "$is_stale" = true ] && is_candidate=true ;;
+      empty) [ "$is_empty" = true ] && is_candidate=true ;;
+      *)
+        if [ "$is_merged" = true ] || [ "$is_stale" = true ] || [ "$is_empty" = true ]; then
+          is_candidate=true
+        fi
+        ;;
+    esac
+
+    if [ "$is_candidate" = true ]; then
+      local tag_parts=()
+      [ "$is_merged" = true ] && tag_parts+=("merged")
+      [ "$is_stale" = true ] && tag_parts+=("stale: ${stale_date}, ${stale_ago}")
+      [ "$is_empty" = true ] && tag_parts+=("empty")
+
+      local tag_str="" t
+      for t in "${tag_parts[@]}"; do
+        [ -z "$tag_str" ] && tag_str="$t" || tag_str="${tag_str}, ${t}"
+      done
+
+      candidate_paths+=("$wt_path")
+      candidate_tags+=("[${tag_str}]")
+      candidate_branches+=("$wt_branch")
+    fi
+  done
+
+  if [ ${#candidate_paths[@]} -eq 0 ]; then
+    echo "No worktrees to clean."
+    exit 0
+  fi
+
+  echo "Worktrees to clean:"
+  for i in "${!candidate_paths[@]}"; do
+    printf "  %-35s %-55s (%s)\n" \
+      "${candidate_paths[$i]}" \
+      "${candidate_tags[$i]}" \
+      "${candidate_branches[$i]}"
+  done
+  echo ""
+
+  if [ "$dry_run" = true ]; then
+    echo "Dry run — no changes made."
+    exit 0
+  fi
+
+  if [ "$force" = false ]; then
+    local count=${#candidate_paths[@]}
+    read -p "Remove ${count} worktree(s)? [y/N] " -r response
+    if [[ ! "$response" =~ ^[Yy]$ ]]; then
+      echo "Aborted."
+      exit 0
+    fi
+  fi
+
+  for i in "${!candidate_paths[@]}"; do
+    remove_worktree "${candidate_paths[$i]}" "$dry_run"
+  done
+}
+
 case "$1" in
   a|add)
     shift
@@ -466,6 +775,11 @@ case "$1" in
   rm|remove)
     shift
     git worktree remove "$@"
+    ;;
+
+  clean)
+    shift
+    cmd_clean "$@"
     ;;
 
   ls|list)

--- a/tests/clean.bats
+++ b/tests/clean.bats
@@ -1,0 +1,252 @@
+#!/usr/bin/env bats
+# Integration tests for git wt clean command
+
+load 'test_helper/bats-support/load'
+load 'test_helper/bats-assert/load'
+load 'test_helper/test_helpers'
+
+setup() {
+  TEST_TEMP_DIR="$(mktemp -d)"
+  cd "$TEST_TEMP_DIR"
+
+  export GIT_AUTHOR_NAME="Test User"
+  export GIT_AUTHOR_EMAIL="test@example.com"
+  export GIT_COMMITTER_NAME="Test User"
+  export GIT_COMMITTER_EMAIL="test@example.com"
+
+  # Initialize git-wt repo (bare + main worktree)
+  bash "$GIT_WT_SCRIPT" init >/dev/null 2>&1
+  cd main
+  git config user.name "Test User"
+  git config user.email "test@example.com"
+  git config init.defaultBranch main
+  echo "initial" > README.md
+  git add README.md
+  git commit -q -m "Initial commit"
+  cd ..
+}
+
+teardown() {
+  cd /
+  rm -rf "$TEST_TEMP_DIR"
+}
+
+# Create a feature worktree with one commit
+create_feature_worktree() {
+  local branch="$1"
+  git worktree add "$branch" -b "$branch" >/dev/null 2>&1
+  cd "$branch"
+  echo "work" > "${branch}.txt"
+  git add "${branch}.txt"
+  git commit -q -m "Add work in ${branch}"
+  cd ..
+}
+
+# Merge a branch into main
+merge_into_main() {
+  local branch="$1"
+  cd main
+  git merge -q --no-ff "$branch" -m "Merge ${branch} into main"
+  cd ..
+}
+
+# Return a date string N days ago (Linux + macOS portable)
+days_ago_date() {
+  local n="$1"
+  date -d "${n} days ago" "+%Y-%m-%dT%H:%M:%S" 2>/dev/null \
+    || date -v-"${n}"d "+%Y-%m-%dT%H:%M:%S" 2>/dev/null
+}
+
+################################################################################
+# clean merge tests
+################################################################################
+
+@test "clean merge detects and removes merged worktrees" {
+  create_feature_worktree "feature1"
+  merge_into_main "feature1"
+
+  run bash "$GIT_WT_SCRIPT" clean merge --force
+  assert_success
+  assert_output --partial "feature1"
+  [ ! -d "feature1" ]
+}
+
+@test "clean merge does not remove worktrees with commits ahead of merged state" {
+  create_feature_worktree "feature1"
+  merge_into_main "feature1"
+
+  # Add a commit after the merge — branch diverges from what was merged
+  cd feature1
+  echo "extra" > extra.txt
+  git add extra.txt
+  git commit -q -m "Extra commit after merge"
+  cd ..
+
+  run bash "$GIT_WT_SCRIPT" clean merge --force
+  assert_success
+  assert_output "No worktrees to clean."
+  [ -d "feature1" ]
+}
+
+@test "clean merge --dry-run shows preview without removing" {
+  create_feature_worktree "feature1"
+  merge_into_main "feature1"
+
+  run bash "$GIT_WT_SCRIPT" clean merge --dry-run
+  assert_success
+  assert_output --partial "feature1"
+  assert_output --partial "Dry run — no changes made."
+  [ -d "feature1" ]
+}
+
+@test "clean merge --force removes without interactive prompt" {
+  create_feature_worktree "feature1"
+  merge_into_main "feature1"
+
+  # Run with --force; no stdin needed
+  run bash "$GIT_WT_SCRIPT" clean merge --force
+  assert_success
+  [ ! -d "feature1" ]
+}
+
+################################################################################
+# clean stale tests
+################################################################################
+
+@test "clean stale detects worktrees with old last-commit dates" {
+  git worktree add stale-wt -b stale-branch >/dev/null 2>&1
+  cd stale-wt
+  echo "work" > stale.txt
+  git add stale.txt
+  OLD_DATE="2020-01-01T00:00:00"
+  GIT_COMMITTER_DATE="$OLD_DATE" git commit -q --date="$OLD_DATE" -m "Old commit"
+  cd ..
+
+  run bash "$GIT_WT_SCRIPT" clean stale 30 --force
+  assert_success
+  assert_output --partial "stale-wt"
+  [ ! -d "stale-wt" ]
+}
+
+@test "clean stale skips worktrees with uncommitted changes" {
+  git worktree add stale-wt -b stale-branch >/dev/null 2>&1
+  cd stale-wt
+  echo "work" > stale.txt
+  git add stale.txt
+  OLD_DATE="2020-01-01T00:00:00"
+  GIT_COMMITTER_DATE="$OLD_DATE" git commit -q --date="$OLD_DATE" -m "Old commit"
+  # Leave dirty file
+  echo "dirty" > dirty.txt
+  cd ..
+
+  run bash "$GIT_WT_SCRIPT" clean stale 30 --force
+  assert_success
+  assert_output "No worktrees to clean."
+  [ -d "stale-wt" ]
+}
+
+@test "clean stale uses custom day threshold - stale when age exceeds threshold" {
+  git worktree add stale-wt -b stale-branch >/dev/null 2>&1
+  cd stale-wt
+  echo "work" > stale.txt
+  git add stale.txt
+  OLD_DATE=$(days_ago_date 10)
+  GIT_COMMITTER_DATE="$OLD_DATE" git commit -q --date="$OLD_DATE" -m "10-day-old commit"
+  cd ..
+
+  # 10 days > threshold 7 → stale
+  run bash "$GIT_WT_SCRIPT" clean stale 7 --force
+  assert_success
+  assert_output --partial "stale-wt"
+  [ ! -d "stale-wt" ]
+}
+
+@test "clean stale uses custom day threshold - not stale when age within threshold" {
+  git worktree add stale-wt -b stale-branch >/dev/null 2>&1
+  cd stale-wt
+  echo "work" > stale.txt
+  git add stale.txt
+  OLD_DATE=$(days_ago_date 10)
+  GIT_COMMITTER_DATE="$OLD_DATE" git commit -q --date="$OLD_DATE" -m "10-day-old commit"
+  cd ..
+
+  # 10 days < threshold 30 → not stale
+  run bash "$GIT_WT_SCRIPT" clean stale 30 --force
+  assert_success
+  assert_output "No worktrees to clean."
+  [ -d "stale-wt" ]
+}
+
+################################################################################
+# clean empty tests
+################################################################################
+
+@test "clean empty detects worktrees with no commits beyond primary" {
+  # Create worktree with no new commits (branch starts at same point as main)
+  git worktree add empty-wt -b empty-branch >/dev/null 2>&1
+
+  run bash "$GIT_WT_SCRIPT" clean empty --force
+  assert_success
+  assert_output --partial "empty-wt"
+  [ ! -d "empty-wt" ]
+}
+
+@test "clean empty skips worktrees with uncommitted changes" {
+  git worktree add empty-wt -b empty-branch >/dev/null 2>&1
+  # Leave a dirty file (not committed)
+  echo "dirty" > empty-wt/dirty.txt
+
+  run bash "$GIT_WT_SCRIPT" clean empty --force
+  assert_success
+  assert_output "No worktrees to clean."
+  [ -d "empty-wt" ]
+}
+
+@test "clean empty skips worktrees with commits beyond primary" {
+  git worktree add empty-wt -b empty-branch >/dev/null 2>&1
+  cd empty-wt
+  echo "extra" > extra.txt
+  git add extra.txt
+  git commit -q -m "Unique commit beyond primary"
+  cd ..
+
+  run bash "$GIT_WT_SCRIPT" clean empty --force
+  assert_success
+  assert_output "No worktrees to clean."
+  [ -d "empty-wt" ]
+}
+
+################################################################################
+# clean (no subcommand) tests
+################################################################################
+
+@test "clean with no subcommand collects all candidates with correct tags" {
+  create_feature_worktree "merged-wt"
+  merge_into_main "merged-wt"
+  git worktree add empty-wt -b empty-branch >/dev/null 2>&1
+
+  run bash "$GIT_WT_SCRIPT" clean --dry-run
+  assert_success
+  assert_output --partial "merged-wt"
+  assert_output --partial "merged"
+  assert_output --partial "empty-wt"
+  assert_output --partial "empty"
+  assert_output --partial "Dry run — no changes made."
+}
+
+@test "clean -n is equivalent to --dry-run" {
+  create_feature_worktree "feature1"
+  merge_into_main "feature1"
+
+  run bash "$GIT_WT_SCRIPT" clean -n
+  assert_success
+  assert_output --partial "Dry run — no changes made."
+  [ -d "feature1" ]
+}
+
+@test "clean reports no candidates when nothing to clean" {
+  # No feature worktrees added
+  run bash "$GIT_WT_SCRIPT" clean --force
+  assert_success
+  assert_output "No worktrees to clean."
+}


### PR DESCRIPTION
## Summary

- Adds `git wt clean` command with three strategies for identifying removable worktrees: `merge`, `stale`, and `empty`
- Bumps version to 0.0.7
- Adds 14 integration tests covering all strategies and flags

## Commands

```
git wt clean                    # find all candidates (merged + stale + empty)
git wt clean merge              # worktrees whose branch is fully merged into primary
git wt clean stale [days]       # worktrees with no activity in N days (default 30)
git wt clean empty              # worktrees with no unique commits and no changes
```

## Flags

- `-n` / `--dry-run` — preview candidates without removing
- `-f` / `--force` — skip confirmation prompt

## Test plan

- [x] `clean merge` detects and removes merged worktrees
- [x] `clean merge` skips worktrees with commits ahead of the merged state
- [x] `clean merge --dry-run` shows preview without removing
- [x] `clean merge --force` removes without interactive prompt
- [x] `clean stale` detects old last-commit dates
- [x] `clean stale` skips worktrees with uncommitted changes
- [x] `clean stale 7` / `clean stale 30` respects custom day threshold
- [x] `clean empty` detects worktrees with no unique commits and no changes
- [x] `clean empty` skips worktrees with uncommitted changes or commits beyond primary
- [x] `clean` (no subcommand) collects all candidates with correct tags
- [x] `clean -n` is equivalent to `--dry-run`
- [x] All 80 existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)